### PR TITLE
Adjust for `moxa-cellular-utils-1.9` and `libqmi-1.14.2`

### DIFF
--- a/build-deb/debian/changelog
+++ b/build-deb/debian/changelog
@@ -1,3 +1,10 @@
+sanji-bundle-cellular (2.0.4-1) unstable; urgency=low
+
+  * Fix: `cell_mgmt` may blocked by `qmi-proxy`.
+  * Fix: unittest.
+
+ -- Aeluin Chen <aeluin.chen@moxa.com>  Fri, 22 Jul 2016 10:42:46 +0800
+
 sanji-bundle-cellular (2.0.3-1) unstable; urgency=low
 
   * Retrieve cell id and lac from `cell_mgmt m_info`.

--- a/build-deb/debian/changelog
+++ b/build-deb/debian/changelog
@@ -1,3 +1,10 @@
+sanji-bundle-cellular (2.0.3-1) unstable; urgency=low
+
+  * Retrieve cell id and lac from `cell_mgmt m_info`.
+  * Use `--uim-get-card-status` instead of `--dms-uim-get-pin-status`.
+
+ -- Aeluin Chen <aeluin.chen@moxa.com>  Thu, 21 Jul 2016 18:11:00 +0800
+
 sanji-bundle-cellular (2.0.2-1) unstable; urgency=low
 
   * Show `nosim` status for unknown status for SIM card.

--- a/build-deb/debian/changelog
+++ b/build-deb/debian/changelog
@@ -1,3 +1,9 @@
+sanji-bundle-cellular (2.0.2-1) unstable; urgency=low
+
+  * Show `nosim` status for unknown status for SIM card.
+
+ -- Aeluin Chen <aeluin.chen@moxa.com>  Thu, 21 Jul 2016 10:18:26 +0800
+
 sanji-bundle-cellular (2.0.1-1) unstable; urgency=low
 
   * Update factory settings.

--- a/build-deb/debian/control
+++ b/build-deb/debian/control
@@ -13,6 +13,6 @@ X-Python-Version: >= 2.5
 Package: sanji-bundle-cellular
 Section: libs
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python2.7, python-pip, vnstat
+Depends: ${shlibs:Depends}, ${misc:Depends}, python2.7, python-pip, vnstat, moxa-cellular-utils (>= 1.9)
 Description: This model provides cellular using QMI.
 

--- a/bundle.json
+++ b/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "cellular",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "TC Huang",
   "email": "tc.huang@moxa.com",
   "description": "Provides the cellular configuration interface",

--- a/bundle.json
+++ b/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "cellular",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": "TC Huang",
   "email": "tc.huang@moxa.com",
   "description": "Provides the cellular configuration interface",

--- a/bundle.json
+++ b/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "cellular",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "TC Huang",
   "email": "tc.huang@moxa.com",
   "description": "Provides the cellular configuration interface",

--- a/cellular_utility/call-qmicli.sh
+++ b/cellular_utility/call-qmicli.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-/usr/lib/libqmi/qmi-proxy &
-
 qmicli $@

--- a/cellular_utility/cell_mgmt.py
+++ b/cellular_utility/cell_mgmt.py
@@ -682,6 +682,8 @@ class CellMgmt(object):
                 return SimStatus.ready
             elif self._sim_status_sim_pin_regex.match(output):
                 return SimStatus.pin
+            else:
+                return SimStatus.nosim
 
         except ErrorReturnCode_60:
             raise

--- a/cellular_utility/cell_mgmt.py
+++ b/cellular_utility/cell_mgmt.py
@@ -250,10 +250,9 @@ class CellMgmt(object):
         r"^\+CPIN:\s*SIM\s+PIN$")
 
     _pin_retry_remain_regex = re.compile(
-        r"\[[\S]+\][\S ]+\n"
-        r"\[[\S]+\] PIN1:\n"
-        r"[\s]*Status:[\s]*[\S]*\n"
-        r"[\s]*Verify:[\s]*([0-9]+)\n"
+        r"[\s\S]*PIN1 state: '([\S]+)'\n"
+        r"[\n\t ]*PIN1 retries: '([0-9]+)'\n"
+        r"[\n\t ]*PUK1 retries: '([0-9]+)'\n"
     )
 
     _at_response_ok_regex = re.compile(
@@ -700,8 +699,8 @@ class CellMgmt(object):
             _logger.warning("no qmi-port exist, return -1")
             return -1
 
-        _logger.debug("qmicli -p -d " + qmi_port + " --dms-uim-get-pin-status")
-        output = self._qmicli("-p", "-d", qmi_port, "--dms-uim-get-pin-status")
+        _logger.debug("qmicli -p -d " + qmi_port + " --uim-get-card-status")
+        output = self._qmicli("-p", "-d", qmi_port, "--uim-get-card-status")
         output = str(output)
 
         match = CellMgmt._pin_retry_remain_regex.match(output)
@@ -709,7 +708,10 @@ class CellMgmt(object):
             _logger.warning("unexpected output: {}".format(output))
             raise CellMgmtError
 
-        return int(match.group(1))
+        if match.group(1) == "disabled":
+            return -1
+
+        return int(match.group(2))
 
     @critical_section
     @handle_error_return_code

--- a/cellular_utility/cell_mgmt.py
+++ b/cellular_utility/cell_mgmt.py
@@ -256,11 +256,6 @@ class CellMgmt(object):
         r"[\s]*Verify:[\s]*([0-9]+)\n"
     )
 
-    _cellular_location_cell_id_regex = re.compile(
-        r"\n[\s]*(?:(?:Cell ID)|(?:Global Cell ID)): '([\S]*)'")
-    _cellular_location_lac_regex = re.compile(
-        r"[\s]*(?:(?:Location Area Code)|(?:Tracking Area Code)): '([\S]*)'")
-
     _at_response_ok_regex = re.compile(
         r"^[\r\n]*([+\S\s :]*)[\r\n]+OK[\r\n]*$")
     _at_response_err_regex = re.compile(
@@ -725,38 +720,10 @@ class CellMgmt(object):
 
         _logger.debug("get_cellular_location")
 
-        qmi_port = self.m_info().qmi_port
-        if qmi_port is None:
-            _logger.warning("no qmi-port exist")
-            raise CellMgmtError
-
-        output = self._qmicli(
-            "-p", "-d", qmi_port, "--nas-get-cell-location-info")
-        output = str(output)
-
-        match = CellMgmt._cellular_location_cell_id_regex.search(output)
-        if not match:
-            _logger.warning("unexpected output: {}".format(output))
-            raise CellMgmtError
-
-        try:
-            cell_id = hex(int(match.group(1)))
-        except ValueError:
-            cell_id = "unavailable"
-
-        match = CellMgmt._cellular_location_lac_regex.search(output)
-        if not match:
-            _logger.warning("unexpected output: {}".format(output))
-            raise CellMgmtError
-
-        try:
-            lac = hex(int(match.group(1)))
-        except ValueError:
-            lac = "unavailable"
-
+        minfo = self.m_info()
         return CellularLocation(
-            cell_id=cell_id,
-            lac=lac)
+            cell_id=minfo.cell_id,
+            lac=minfo.lac)
 
 
 if __name__ == "__main__":

--- a/cellular_utility/tests/test_cell_mgmt.py
+++ b/cellular_utility/tests/test_cell_mgmt.py
@@ -171,8 +171,7 @@ class TestCellMgmt(unittest.TestCase):
                "\t\t\tPUK1 retries: '10'\n"
                "\t\tPIN2 state: 'blocked'\n"
                "\t\t\tPIN2 retries: '0'\n"
-               "\t\t\tPUK2 retries: '10'\n"
-        )
+               "\t\t\tPUK2 retries: '10'\n")
 
         # act
         match = CellMgmt._pin_retry_remain_regex.match(SUT)

--- a/cellular_utility/tests/test_cell_mgmt.py
+++ b/cellular_utility/tests/test_cell_mgmt.py
@@ -5,8 +5,7 @@ import os
 import sys
 import logging
 import unittest
-from mock import patch
-from mock import Mock, MagicMock
+from mock import patch, Mock
 
 
 def mock_retrying(f):
@@ -16,7 +15,7 @@ def mock_retrying(f):
 
 try:
     sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../")
-    patch('cellular_utility.cell_mgmt.retrying', lambda x:x).start()
+    patch('cellular_utility.cell_mgmt.retrying', lambda x: x).start()
     from cellular_utility.cell_mgmt import CellMgmt, CellMgmtError
 except ImportError as e:
     print os.path.dirname(os.path.realpath(__file__)) + "/../"
@@ -144,7 +143,6 @@ class TestCellMgmt(unittest.TestCase):
 
         # assert
         self.assertTrue(match)
-
 
     def test_sim_status_ready_regex_should_pass(self):
         # arrange
@@ -307,7 +305,7 @@ class TestCellMgmt(unittest.TestCase):
 
         # assert
         with self.assertRaises(CellMgmtError):
-            res = self.cell_mgmt.at("at")
+            self.cell_mgmt.at("at")
 
 
 if __name__ == "__main__":

--- a/cellular_utility/tests/test_cell_mgmt.py
+++ b/cellular_utility/tests/test_cell_mgmt.py
@@ -148,16 +148,30 @@ class TestCellMgmt(unittest.TestCase):
 
     def test_pin_retry_remain_regex_should_pass(self):
         # arrange
-        SUT = (
-            "[/dev/cdc-wdm0] PIN status retrieved successfully\n"
-            "[/dev/cdc-wdm0] PIN1:\n"
-            "\tStatus: enabled-not-verified\n"
-            "\tVerify: 3\n"
-            "\tUnblock: 10\n"
-            "[/dev/cdc-wdm0] PIN2:\n"
-            "\tStatus: blocked\n"
-            "\tVerify: 0\n"
-            "\tUnblock: 10\n"
+        SUT = ("[/dev/cdc-wdm1] Successfully got card status\n"
+               "Provisioning applications:\n"
+               "\tPrimary GW:   slot '0', application '0'\n"
+               "\tPrimary 1X:   session doesn't exist\n"
+               "\tSecondary GW: session doesn't exist\n"
+               "\tSecondary 1X: session doesn't exist\n"
+               "Card [0]:\n"
+               "\tCard state: 'present'\n"
+               "\tUPIN state: 'not-initialized'\n"
+               "\t\tUPIN retries: '0'\n"
+               "\t\tUPUK retries: '0'\n"
+               "\tApplication [0]:\n"
+               "\t\tApplication type:  'usim (2)'\n"
+               "\t\tApplication state: 'ready'\n"
+               "\t\tApplication ID:\n"
+               "\t\t\tA0:00:00:00:87:10:02:FF:33:FF:01:89:06:05:00:FF\n"
+               "\t\tPersonalization state: 'ready'\n"
+               "\t\tUPIN replaces PIN1: 'no'\n"
+               "\t\tPIN1 state: 'enabled-verified'\n"
+               "\t\t\tPIN1 retries: '3'\n"
+               "\t\t\tPUK1 retries: '10'\n"
+               "\t\tPIN2 state: 'blocked'\n"
+               "\t\t\tPIN2 retries: '0'\n"
+               "\t\t\tPUK2 retries: '10'\n"
         )
 
         # act
@@ -165,301 +179,8 @@ class TestCellMgmt(unittest.TestCase):
 
         # assert
         self.assertTrue(match)
-        self.assertEqual("3", match.group(1))
+        self.assertEqual("3", match.group(2))
 
-    QMICLI_NAS_GET_CELL_LOCATION_INFO_OUTPUT = (
-        "[/dev/cdc-wdm0] Successfully got cell location info\n"
-        "UMTS Info\n"
-        "	Cell ID: '15086'\n"
-        "	PLMN: '466'\n"
-        "	Location Area Code: '10263'\n"
-        "	UTRA Absolute RF Channel Number: '10762'\n"
-        "	Primary Scrambling Code: '33'\n"
-        "	RSCP: '-109' dBm\n"
-        "	ECIO: '-17' dBm\n"
-        "	Cell [0]:\n"
-        "		UTRA Absolute RF Channel Number: '10762'\n"
-        "		Primary Scrambling Code: '335'\n"
-        "		RSCP: '-116' dBm\n"
-        "		ECIO: '-19' dBm\n"
-        "	Cell [1]:\n"
-        "		UTRA Absolute RF Channel Number: '10762'\n"
-        "		Primary Scrambling Code: '472'\n"
-        "		RSCP: '-121' dBm\n"
-        "		ECIO: '-24' dBm\n"
-        "	Cell [2]:\n"
-        "		UTRA Absolute RF Channel Number: '10762'\n"
-        "		Primary Scrambling Code: '480'\n"
-        "		RSCP: '-121' dBm\n"
-        "		ECIO: '-25' dBm\n"
-        "	Neighboring GERAN Cell [0]:\n"
-        "		GERAN Absolute RF Channel Number: '569'\n"
-        "		Network Color Code: '1'\n"
-        "		Base Station Color Code: '2'\n"
-        "		RSSI: '65438'\n"
-        "	Neighboring GERAN Cell [1]:\n"
-        "		GERAN Absolute RF Channel Number: '578'\n"
-        "		Network Color Code: 'unavailable'\n"
-        "		Base Station Color Code: 'unavailable'\n"
-        "		RSSI: '65432'\n"
-        "	Neighboring GERAN Cell [2]:\n"
-        "		GERAN Absolute RF Channel Number: '589'\n"
-        "		Network Color Code: 'unavailable'\n"
-        "		Base Station Color Code: 'unavailable'\n"
-        "		RSSI: '65424'\n"
-        "	Neighboring GERAN Cell [3]:\n"
-        "		GERAN Absolute RF Channel Number: '67'\n"
-        "		Network Color Code: 'unavailable'\n"
-        "		Base Station Color Code: 'unavailable'\n"
-        "		RSSI: '65424'\n"
-        "	Neighboring GERAN Cell [4]:\n"
-        "		GERAN Absolute RF Channel Number: '587'\n"
-        "		Network Color Code: 'unavailable'\n"
-        "		Base Station Color Code: 'unavailable'\n"
-        "		RSSI: '65423'\n"
-        "	Neighboring GERAN Cell [5]:\n"
-        "		GERAN Absolute RF Channel Number: '584'\n"
-        "		Network Color Code: 'unavailable'\n"
-        "		Base Station Color Code: 'unavailable'\n"
-        "		RSSI: '65423'\n"
-        "	Neighboring GERAN Cell [6]:\n"
-        "		GERAN Absolute RF Channel Number: '595'\n"
-        "		Network Color Code: 'unavailable'\n"
-        "		Base Station Color Code: 'unavailable'\n"
-        "		RSSI: '65422'\n"
-        "	Neighboring GERAN Cell [7]:\n"
-        "		GERAN Absolute RF Channel Number: '73'\n"
-        "		Network Color Code: 'unavailable'\n"
-        "		Base Station Color Code: 'unavailable'\n"
-        "		RSSI: '65422'\n"
-        "UMTS Cell ID: '17251054'\n"
-        "UMTS Info Neighboring LTE\n"
-        "	RRC State: 'disconnected'\n"
-        "	Frequency [0]:\n"
-        "		EUTRA Absolute RF Channel Number: '1725'\n"
-        "		Physical Cell ID: '388'\n"
-        "		RSRP: '-126.000000' dBm\n"
-        "		RSRQ: '-14.000000' dB\n"
-        "		Cell Selection RX Level: '-6'\n"
-        "		Is TDD?: 'no'\n"
-        "	Frequency [1]:\n"
-        "		EUTRA Absolute RF Channel Number: '3650'\n"
-        "		Physical Cell ID: '166'\n"
-        "		RSRP: '-128.000000' dBm\n"
-        "		RSRQ: '-14.000000' dB\n"
-        "		Cell Selection RX Level: '-8'\n"
-        "		Is TDD?: 'no'\n")
-
-    def test_cellular_location_cell_id_regex_should_pass(self):
-        # arrange
-        SUT = TestCellMgmt.QMICLI_NAS_GET_CELL_LOCATION_INFO_OUTPUT
-
-        # act
-        match = CellMgmt._cellular_location_cell_id_regex.search(SUT)
-
-        # assert
-        self.assertTrue(match)
-        print match.group(0)
-        self.assertEqual("15086", match.group(1))
-
-    def test_cellular_location_lac_regex_should_pass(self):
-        # arrange
-        SUT = TestCellMgmt.QMICLI_NAS_GET_CELL_LOCATION_INFO_OUTPUT
-
-        # act
-        match = CellMgmt._cellular_location_lac_regex.search(SUT)
-
-        # assert
-        self.assertTrue(match)
-        self.assertEqual("10263", match.group(1))
-
-    def test_cellular_location_cell_id_regex_with_unavailable_should_pass(
-            self):
-        # arrange
-        SUT = (
-            "[/dev/cdc-wdm0] Successfully got cell location info\n"
-            "UMTS Info\n"
-            "    Cell ID: 'unavailable'\n"
-            "    PLMN: '466'\n"
-            "    Location Area Code: '10233'\n"
-            "    UTRA Absolute RF Channel Number: '10762'\n"
-            "    Primary Scrambling Code: '335'\n"
-            "    RSCP: '-81' dBm\n"
-            "    ECIO: '-11' dBm\n"
-            "    Cell [0]:\n"
-            "        UTRA Absolute RF Channel Number: '10787'\n"
-            "        Primary Scrambling Code: '33'\n"
-            "        RSCP: '-89' dBm\n"
-            "        ECIO: '-17' dBm\n"
-            "    Cell [1]:\n"
-            "        UTRA Absolute RF Channel Number: '10787'\n"
-            "        Primary Scrambling Code: '365'\n"
-            "        RSCP: '-90' dBm\n"
-            "        ECIO: '-18' dBm\n"
-            "    Cell [2]:\n"
-            "        UTRA Absolute RF Channel Number: '10787'\n"
-            "        Primary Scrambling Code: '223'\n"
-            "        RSCP: '-92' dBm\n"
-            "        ECIO: '-20' dBm\n"
-            "    Cell [3]:\n"
-            "        UTRA Absolute RF Channel Number: '10787'\n"
-            "        Primary Scrambling Code: '343'\n"
-            "        RSCP: '-92' dBm\n"
-            "        ECIO: '-20' dBm\n"
-            "    Cell [4]:\n"
-            "        UTRA Absolute RF Channel Number: '10787'\n"
-            "        Primary Scrambling Code: '480'\n"
-            "        RSCP: '-94' dBm\n"
-            "        ECIO: '-21' dBm\n"
-            "    Cell [5]:\n"
-            "        UTRA Absolute RF Channel Number: '10787'\n"
-            "        Primary Scrambling Code: '207'\n"
-            "        RSCP: '-94' dBm\n"
-            "        ECIO: '-22' dBm\n"
-            "UMTS Cell ID: '4294967295'\n"
-            "UMTS Info Neighboring LTE\n"
-            "    RRC State: 'cell-dch'\n")
-
-        # act
-        match = CellMgmt._cellular_location_cell_id_regex.search(SUT)
-
-        # assert
-        self.assertTrue(match)
-        self.assertEqual("unavailable", match.group(1))
-
-    QMICLI_NAS_GET_CELL_LOCATION_INFO_LTE_OUTPUT = (
-        "[/dev/cdc-wdm0] Successfully got cell location info\n"
-        "Intrafrequency LTE Info\n"
-        "        UE In Idle: 'yes'\n"
-        "        PLMN: '466'\n"
-        "        Tracking Area Code: '12000'\n"
-        "        Global Cell ID: '29419041'\n"
-        "        EUTRA Absolute RF Channel Number: '1725'\n"
-        "        Serving Cell ID: '56'\n"
-        "        Cell Reselection Priority: '6'\n"
-        "        S Non Intra Search Threshold: '6'\n"
-        "        Serving Cell Low Threshold: '4'\n"
-        "        S Intra Search Threshold: '62'\n"
-        "        Cell [0]:\n"
-        "                Physical Cell ID: '56'\n"
-        "                RSRQ: '-6.5' dB\n"
-        "                RSRP: '-78.3' dBm\n"
-        "                RSSI: '-53.1' dBm\n"
-        "                Cell Selection RX Level: '41'\n"
-        "        Cell [1]:\n"
-        "                Physical Cell ID: '429'\n"
-        "                RSRQ: '-20.0' dB\n"
-        "                RSRP: '-97.1' dBm\n"
-        "                RSSI: '-66.4' dBm\n"
-        "                Cell Selection RX Level: '22'\n"
-        "Interfrequency LTE Info\n"
-        "        UE In Idle: 'yes'\n"
-        "        Frequency [0]:\n"
-        "                EUTRA Absolute RF Channel Number: '3650'\n"
-        "                Selection RX Level Low Threshold: '0'\n"
-        "                Cell Selection RX Level High Threshold: '8'\n"
-        "                Cell Reselection Priority: '5'\n"
-        "LTE Info Neighboring GSM\n"
-        "        UE In Idle: 'yes'\n"
-        "        Frequency [0]:\n"
-        "                Cell Reselection Priority: '2'\n"
-        "                Cell Reselection High Threshold: '4'\n"
-        "                Cell Reselection Low Threshold: '10'\n"
-        "                NCC Permitted: '0xFF'\n"
-        "                Cell [0]:\n"
-        "                        GERAN Absolute RF Channel Number: '25'\n"
-        "                        Band Is 1900: 'no'\n"
-        "                        Base Station Identity Code: 'unknown'\n"
-        "                        RSSI: '-192.0' dB\n"
-        "                        Cell Selection RX Level: '0'\n"
-        "                Cell [1]:\n"
-        "                        GERAN Absolute RF Channel Number: '26'\n"
-        "                        Band Is 1900: 'no'\n"
-        "                        Base Station Identity Code: 'unknown'\n"
-        "                        RSSI: '-192.0' dB\n"
-        "                        Cell Selection RX Level: '0'\n"
-        "                Cell [2]:\n"
-        "                        GERAN Absolute RF Channel Number: '27'\n"
-        "                        Band Is 1900: 'no'\n"
-        "                        Base Station Identity Code: 'unknown'\n"
-        "                        RSSI: '-192.0' dB\n"
-        "                        Cell Selection RX Level: '0'\n"
-        "                Cell [3]:\n"
-        "                        GERAN Absolute RF Channel Number: '28'\n"
-        "                        Band Is 1900: 'no'\n"
-        "                        Base Station Identity Code: 'unknown'\n"
-        "                        RSSI: '-192.0' dB\n"
-        "                        Cell Selection RX Level: '0'\n"
-        "                Cell [4]:\n"
-        "                        GERAN Absolute RF Channel Number: '29'\n"
-        "                        Band Is 1900: 'no'\n"
-        "                        Base Station Identity Code: 'unknown'\n"
-        "                        RSSI: '-192.0' dB\n"
-        "                        Cell Selection RX Level: '0'\n"
-        "                Cell [5]:\n"
-        "                        GERAN Absolute RF Channel Number: '30'\n"
-        "                        Band Is 1900: 'no'\n"
-        "                        Base Station Identity Code: 'unknown'\n"
-        "                        RSSI: '-192.0' dB\n"
-        "                        Cell Selection RX Level: '0'\n"
-        "                Cell [6]:\n"
-        "                        GERAN Absolute RF Channel Number: '31'\n"
-        "                        Band Is 1900: 'no'\n"
-        "                        Base Station Identity Code: 'unknown'\n"
-        "                        RSSI: '-192.0' dB\n"
-        "                        Cell Selection RX Level: '0'\n"
-        "                Cell [7]:\n"
-        "                        GERAN Absolute RF Channel Number: '32'\n"
-        "                        Band Is 1900: 'no'\n"
-        "                        Base Station Identity Code: 'unknown'\n"
-        "                        RSSI: '-192.0' dB\n"
-        "                        Cell Selection RX Level: '0'\n"
-        "        Frequency [1]:\n"
-        "                Cell Reselection Priority: '1'\n"
-        "                Cell Reselection High Threshold: '4'\n"
-        "                Cell Reselection Low Threshold: '10'\n"
-        "                NCC Permitted: '0xFF'\n"
-        "                Cell [0]:\n"
-        "                        GERAN Absolute RF Channel Number: '569'\n"
-        "                        Band Is 1900: 'no'\n"
-        "                        Base Station Identity Code: 'unknown'\n"
-        "                        RSSI: '-192.0' dB\n"
-        "                        Cell Selection RX Level: '0'\n"
-        "LTE Info Neighboring WCDMA\n"
-        "        UE In Idle: 'yes'\n"
-        "        Frequency [0]:\n"
-        "                UTRA Absolute RF Channel Number: '10762'\n"
-        "                Cell Reselection Priority: '4'\n"
-        "                Cell Reselection High Threshold: '8'\n"
-        "                Cell Reselection Low Threshold: '6'\n"
-        "        Frequency [1]:\n"
-        "                UTRA Absolute RF Channel Number: '10787'\n"
-        "                Cell Reselection Priority: '4'\n"
-        "                Cell Reselection High Threshold: '8'\n"
-        "                Cell Reselection Low Threshold: '6'\n"
-    )
-
-    def test_cellular_location_cell_id_regex_with_lte_output_should_pass(self):
-        # arrange
-        SUT = TestCellMgmt.QMICLI_NAS_GET_CELL_LOCATION_INFO_LTE_OUTPUT
-
-        # act
-        match = CellMgmt._cellular_location_cell_id_regex.search(SUT)
-
-        # assert
-        self.assertTrue(match)
-        self.assertEqual("29419041", match.group(1))
-
-    def test_cellular_location_lac_regex_with_lte_output_should_pass(self):
-        # arrange
-        SUT = TestCellMgmt.QMICLI_NAS_GET_CELL_LOCATION_INFO_LTE_OUTPUT
-
-        # act
-        match = CellMgmt._cellular_location_lac_regex.search(SUT)
-
-        # assert
-        self.assertTrue(match)
-        self.assertEqual("12000", match.group(1))
 
 if __name__ == "__main__":
     FORMAT = "%(asctime)s - %(levelname)s - %(lineno)s - %(message)s"


### PR DESCRIPTION
1. Change status to nosim for unknown status
2. Retrieve cell id and lac from `cell_mgmt m_info`
3. Use `--uim-get-card-status` instead of `--dms-uim-get-pin-status`.