### PR TITLE
Improve availability

### DIFF
--- a/build-deb/debian/changelog
+++ b/build-deb/debian/changelog
@@ -1,3 +1,12 @@
+sanji-bundle-cellular (2.0.1+2-1) unstable; urgency=low
+
+  * fix: sh default timeout
+  * fix: Power cycle the module for unknown crash.
+  * fix: Add timeout for RLock in cell_mgmt.
+  * feat: Add monit for external keepalive.
+
+ -- Aeluin Chen <aeluin.chen@moxa.com>  Tue, 30 Aug 2016 15:22:54 +0800
+
 sanji-bundle-cellular (2.0.1+1-1) unstable; urgency=low
 
   * Fix: Query signal failed under CDMA.

--- a/build-deb/debian/control
+++ b/build-deb/debian/control
@@ -13,6 +13,6 @@ X-Python-Version: >= 2.5
 Package: sanji-bundle-cellular
 Section: libs
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python2.7, python-pip, vnstat
+Depends: ${shlibs:Depends}, ${misc:Depends}, python2.7, python-pip, vnstat, moxa-cellular-utils (>= 1.7.2)
 Description: This model provides cellular using QMI.
 

--- a/bundle.json
+++ b/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "cellular",
-  "version": "2.0.1+1",
+  "version": "2.0.1+2",
   "author": "TC Huang",
   "email": "tc.huang@moxa.com",
   "description": "Provides the cellular configuration interface",

--- a/cellular_utility/cell_mgmt.py
+++ b/cellular_utility/cell_mgmt.py
@@ -83,6 +83,7 @@ def critical_section(func, *args, **kwargs):
     with CellMgmt._lock:
         return func(*args, **kwargs)
 
+
 def sh_default_timeout(func, timeout):
     def _sh_default_timeout(*args, **kwargs):
         if kwargs.get("_timeout", None) is None:
@@ -485,13 +486,13 @@ class CellMgmt(object):
 
     @handle_error_return_code
     @retry_on_busy
-    def _power_off(self):
+    def _power_off(self, force=False):
         """
         Power off Cellular module.
         """
         _logger.debug("cell_mgmt power_off")
 
-        self._cell_mgmt("power_off")
+        self._cell_mgmt("power_off", "force" if force else "")
 
         # sleep to make sure GPIO is pulled down for enough time
         sleep(1)
@@ -501,13 +502,14 @@ class CellMgmt(object):
 
     @handle_error_return_code
     @retry_on_busy
-    def _power_on(self, timeout_sec=60):
+    def _power_on(self, force=False, timeout_sec=60):
         """
         Power on Cellular module.
         """
         _logger.debug("cell_mgmt power_on")
 
-        self._cell_mgmt("power_on", _timeout=timeout_sec)
+        self._cell_mgmt(
+            "power_on", "force" if force else "", _timeout=timeout_sec)
 
         if self._invoke_period_sec != 0:
             sleep(self._invoke_period_sec)
@@ -515,13 +517,13 @@ class CellMgmt(object):
     @critical_section
     @handle_error_return_code
     @retry_on_busy
-    def power_cycle(self, timeout_sec=60):
+    def power_cycle(self, force=False, timeout_sec=60):
         """
         Power cycle Cellular module.
         """
-        self._power_off()
+        self._power_off(force)
         sleep(1)
-        self._power_on(timeout_sec)
+        self._power_on(force, timeout_sec)
 
     @critical_section
     @handle_error_return_code

--- a/cellular_utility/cell_mgmt.py
+++ b/cellular_utility/cell_mgmt.py
@@ -81,7 +81,7 @@ def retry_on_busy(func, *args, **kwargs):
 @decorator
 def critical_section(func, *args, **kwargs):
     if CellMgmt._lock._RLock__owner == thread.get_ident() \
-        or CellMgmt._lock._RLock__owner is None:
+            or CellMgmt._lock._RLock__owner is None:
         with CellMgmt._lock:
             return func(*args, **kwargs)
 

--- a/cellular_utility/management.py
+++ b/cellular_utility/management.py
@@ -309,12 +309,6 @@ class Manager(object):
 
         self._update_network_information_callback = None
 
-        if self._pdp_context_static is True:
-            self._cell_mgmt.set_pdp_context(
-                self._pdp_context_id,
-                self._pdp_context_apn,
-                self._pdp_context_type)
-
         self._log = Log()
 
     def set_update_network_information_callback(
@@ -364,6 +358,12 @@ class Manager(object):
     def _main_thread(self):
         while True:
             try:
+                if self._pdp_context_static is True:
+                    self._cell_mgmt.set_pdp_context(
+                        self._pdp_context_id,
+                        self._pdp_context_apn,
+                        self._pdp_context_type)
+
                 self._loop()
 
             except StopException:

--- a/schema/index.yaml
+++ b/schema/index.yaml
@@ -218,6 +218,21 @@ definitions:
           intervalSec:
             type: integer
             description: Check alive interval.
+          reboot:
+            type: object
+            description: |
+              Reboot system while check alive failed after a defined cycle(s).
+            properties:
+              enable:
+                type: boolean
+                description: |
+                  Enable/disable reboot policy for check alive failed.
+              cycles:
+                type: integer
+                description: |
+                  Define cycles to check if reboot is required; a cycle is
+                  a global value defined by system, default should be 30
+                  minutes.
     example:
           $ref: '#/externalDocs/x-mocks/Cellular'
 
@@ -263,7 +278,11 @@ externalDocs:
         "keepalive": {
           "enable": true,
           "targetHost": "8.8.8.8",
-          "intervalSec": 60
+          "intervalSec": 60,
+          "reboot": {
+            "enable": false,
+            "cycles": 1
+          }
         }
       }
     Cellulars:

--- a/schema/index.yaml
+++ b/schema/index.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: Cellular API
   description: Handle the Cellular interface(s)
-  version: "2.0.0"
+  version: "2.1.0"
 
 schemes:
   - http

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -31,7 +31,11 @@ class TestCellularStatic(unittest.TestCase):
             "keepalive": {
                 "enable": True,
                 "targetHost": "8.8.8.8",
-                "intervalSec": 60
+                "intervalSec": 60,
+                "reboot": {
+                    "enable": False,
+                    "cycles": 1
+                }
             }
         }
 
@@ -55,7 +59,11 @@ class TestCellularStatic(unittest.TestCase):
             "keepalive": {
                 "enable": True,
                 "targetHost": "8.8.8.8",
-                "intervalSec": 60
+                "intervalSec": 60,
+                "reboot": {
+                    "enable": False,
+                    "cycles": 1
+                }
             }
         }
 
@@ -79,7 +87,11 @@ class TestCellularStatic(unittest.TestCase):
             "keepalive": {
                 "enable": True,
                 "targetHost": "8.8.8.8",
-                "intervalSec": 60
+                "intervalSec": 60,
+                "reboot": {
+                    "enable": False,
+                    "cycles": 1
+                }
             }
         }
 


### PR DESCRIPTION
- docs: Add `reboot` for a keepalive policy
- fix: `sh` default timeout
- fix: Power cycle the module for unknown crash
- fix: Add timeout for RLock in cell_mgmt	
- feat: Add monit for external keepalive
- Change PDP context setting into init process