### PR TITLE
fix: typo makes `get_profiles` failed

### DIFF
--- a/build-deb/debian/changelog
+++ b/build-deb/debian/changelog
@@ -1,3 +1,10 @@
+sanji-bundle-cellular (3.1.2-1) unstable; urgency=low
+
+  * fix: use `>>` instead of `>` in dependency.
+  * fix: typo makes `get_profiles` failed.
+
+ -- Aeluin Chen <aeluin.chen@moxa.com>  Fri, 24 Feb 2017 11:41:26 +0800
+
 sanji-bundle-cellular (3.1.1-1) unstable; urgency=low
 
   * Use `cell_mgmt get_profiles` to get profiles.

--- a/build-deb/debian/control
+++ b/build-deb/debian/control
@@ -13,6 +13,6 @@ X-Python-Version: >= 2.5
 Package: sanji-bundle-cellular
 Section: libs
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python2.7, python-pip, vnstat, moxa-cellular-utils (> 1.10.5)
+Depends: ${shlibs:Depends}, ${misc:Depends}, python2.7, python-pip, vnstat, moxa-cellular-utils (>> 1.10.5)
 Description: This model provides cellular using QMI.
 

--- a/bundle.json
+++ b/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "cellular",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "author": "Aeluin Chen",
   "email": "aeluin.chen@moxa.com",
   "description": "Provides the cellular configuration interface",

--- a/cellular_utility/cell_mgmt.py
+++ b/cellular_utility/cell_mgmt.py
@@ -694,7 +694,7 @@ class CellMgmt(object):
             pdpc_list = []
             res = self._cell_mgmt("get_profiles")
 
-            for item in res["info"].splitlines(True):
+            for item in res.splitlines(True):
                 pdpc = self._split_param_by_comma_regex.findall(item)
                 if len(pdpc) <= 3:
                     continue


### PR DESCRIPTION
- fix: use `>>` instead of `>` in dependency
- fix: typo makes `get_profiles` failed