### PR TITLE
3.6.4

### DIFF
--- a/build-deb/debian/changelog
+++ b/build-deb/debian/changelog
@@ -1,3 +1,9 @@
+sanji-bundle-cellular (3.6.4-1) unstable; urgency=low
+
+  * fix: Use `basestring` instead of `str`.
+
+ -- Aeluin Chen <aeluin.chen@moxa.com>  Thu, 23 Nov 2017 14:30:50 +0800
+
 sanji-bundle-cellular (3.6.3-1) unstable; urgency=low
 
   * test: Fix unittest.

--- a/bundle.json
+++ b/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "cellular",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "author": "Aeluin Chen",
   "email": "aeluin.chen@moxa.com",
   "description": "Provides the cellular configuration interface",

--- a/cellular_utility/management.py
+++ b/cellular_utility/management.py
@@ -370,7 +370,7 @@ class Manager(object):
                      pdp_context_secondary_password is None) or
                 not isinstance(pdp_context_retry_timeout, int) or
                 not isinstance(keepalive_enabled, bool) or
-                not isinstance(keepalive_host, str) or
+                not isinstance(keepalive_host, basestring) or
                 not isinstance(keepalive_period_sec, int) or
                 not isinstance(log_period_sec, int)):
             raise ValueError

--- a/data/cellular.json.factory
+++ b/data/cellular.json.factory
@@ -9,10 +9,16 @@
       "id": 1,
       "retryTimeout": 600,
       "primary": {
+        "auth": {
+          "protocol": "none"
+        },
         "apn": "internet",
         "type": "ipv4v6"
       },
       "secondary": {
+        "auth": {
+          "protocol": "none"
+        },
         "type": "ipv4v6"
       }
     },

--- a/index.py
+++ b/index.py
@@ -64,7 +64,7 @@ class Index(Sanji):
             Required("pinCode", default=""): Any(Match(r"[0-9]{4,4}"), ""),
             Required("keepalive"): {
                 Required("enable"): bool,
-                Required("targetHost"): str,
+                Required("targetHost"): basestring,
                 Required("intervalSec"): All(
                     int,
                     Any(0, Range(min=60, max=86400 - 1))


### PR DESCRIPTION
- fix: Use `basestring` instead of `str`