### PR TITLE
3.6.5

### DIFF
--- a/build-deb/debian/changelog
+++ b/build-deb/debian/changelog
@@ -1,3 +1,9 @@
+sanji-bundle-cellular (3.6.5-1) unstable; urgency=low
+
+  * fix: Use `basestring` instead of `str`.
+
+ -- Aeluin Chen <aeluin.chen@moxa.com>  Thu, 23 Nov 2017 15:18:44 +0800
+
 sanji-bundle-cellular (3.6.4-1) unstable; urgency=low
 
   * fix: Use `basestring` instead of `str`.

--- a/bundle.json
+++ b/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "cellular",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "author": "Aeluin Chen",
   "email": "aeluin.chen@moxa.com",
   "description": "Provides the cellular configuration interface",

--- a/cellular_utility/management.py
+++ b/cellular_utility/management.py
@@ -40,16 +40,16 @@ class CellularInformation(object):
             cell_id=None,
             bid=None):
 
-        if (not isinstance(mode, str) or
+        if (not isinstance(mode, basestring) or
                 not isinstance(signal_csq, int) or
                 not isinstance(signal_rssi_dbm, int) or
                 not isinstance(signal_ecio_dbm, float) or
-                not isinstance(operator, str) or
-                not isinstance(lac, str) or
-                not isinstance(tac, str) or
-                not isinstance(nid, str) or
-                not isinstance(cell_id, str) or
-                not isinstance(bid, str)):
+                not isinstance(operator, basestring) or
+                not isinstance(lac, basestring) or
+                not isinstance(tac, basestring) or
+                not isinstance(nid, basestring) or
+                not isinstance(cell_id, basestring) or
+                not isinstance(bid, basestring)):
             raise ValueError
 
         if lac == "Unknown" or cell_id == "Unknown":
@@ -265,9 +265,9 @@ class Manager(object):
                 esn=None,
                 mac=None):
 
-            if (not isinstance(imei, str) or
-                    not isinstance(esn, str) or
-                    not isinstance(mac, str)):
+            if (not isinstance(imei, basestring) or
+                    not isinstance(esn, basestring) or
+                    not isinstance(mac, basestring)):
                 raise ValueError
 
             self._imei = imei
@@ -295,9 +295,9 @@ class Manager(object):
                 imei=None):
 
             if (not isinstance(pin_retry_remain, int) or
-                    not isinstance(iccid, str) or
-                    not isinstance(imsi, str) or
-                    not isinstance(imei, str)):
+                    not isinstance(iccid, basestring) or
+                    not isinstance(imsi, basestring) or
+                    not isinstance(imei, basestring)):
                 raise ValueError
 
             self._pin_retry_remain = pin_retry_remain
@@ -344,7 +344,7 @@ class Manager(object):
             keepalive_period_sec=None,
             log_period_sec=None):
 
-        if (not isinstance(dev_name, str) or
+        if (not isinstance(dev_name, basestring) or
                 not isinstance(enabled, bool) or
                 not isinstance(pdp_context_static, bool) or
                 not isinstance(pdp_context_id, int) or
@@ -376,7 +376,7 @@ class Manager(object):
             raise ValueError
 
         if pin is not None:
-            if not isinstance(pin, str) or len(pin) != 4:
+            if not isinstance(pin, basestring) or len(pin) != 4:
                 raise ValueError
 
         self._dev_name = dev_name


### PR DESCRIPTION
- fix: Use `basestring` instead of `str`