### PR TITLE
3.6.7-2

### DIFF
--- a/build-deb/Makefile
+++ b/build-deb/Makefile
@@ -4,7 +4,7 @@ NAME        = $(shell cat $(PROJ_DIR)/bundle.json | sed -n 's/"name"//p' | tr -d
 VERSION     = $(shell cat $(PROJ_DIR)/bundle.json | sed -n 's/"version"//p' | tr -d '", :')
 
 PROJECT     = sanji-bundle-$(NAME)
-DEBVERSION  = 1
+DEBVERSION  = 2
 DIST        ?= unstable
 
 STAGING_DIR = $(abspath $(PROJECT)-$(VERSION))

--- a/build-deb/debian/changelog
+++ b/build-deb/debian/changelog
@@ -1,3 +1,10 @@
+sanji-bundle-cellular (3.6.7-2) unstable; urgency=low
+
+  * chore: Add missing dependency `iputils-ping`.
+  * chore: Add version for dependency `vnstat`.
+
+ -- Aeluin Chen <aeluin.chen@moxa.com>  Thu, 18 Jan 2018 15:16:36 +0800
+
 sanji-bundle-cellular (3.6.7-1) unstable; urgency=low
 
   * fix: Provide default value for "auth".

--- a/build-deb/debian/control
+++ b/build-deb/debian/control
@@ -13,6 +13,12 @@ X-Python-Version: >= 2.5
 Package: sanji-bundle-cellular
 Section: libs
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python2.7, python-pip, vnstat, moxa-cellular-utils (>= 1.20.0)
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         python2.7,
+         python-pip,
+         vnstat (>= 1.12-2),
+         iputils-ping,
+         moxa-cellular-utils (>= 1.20.0)
 Description: This model provides cellular using QMI.
 


### PR DESCRIPTION
* chore: Add missing dependency `iputils-ping`.
* chore: Add version for dependency `vnstat`.